### PR TITLE
Implemented a first version of SanlaMessagePackage.

### DIFF
--- a/include/common/SanlaMessage.hpp
+++ b/include/common/SanlaMessage.hpp
@@ -9,12 +9,12 @@
 namespace sanla {
     namespace sanlamessage {
         const uint8_t RECIPIENT_ID_MAX_SIZE {16};
-        const std::byte BRO {0x1}, REQ {0x2}, PRO {0x3}, PAC {0x4}, ACK {0x8},
+        const u_char BRO {0x1}, REQ {0x2}, PRO {0x3}, PAC {0x4}, ACK {0x8},
         SEN {0xC}, RES {0xA}, PACREQ {0x6}, PACPRO {0x7}, PROACK {0xB},
         PACSEN {0xF}, PACRES {0xD};
 
         struct SanlaPacket {
-            std::byte flags;
+            u_char flags;
             long package_id;
             uint16_t sender_id;
             char recipient_id[RECIPIENT_ID_MAX_SIZE];
@@ -30,19 +30,36 @@ namespace sanla {
         char* payload;
     };
 
-    // TODO decide if this is copyable and/or moveable or neither
-    // see: https://google.github.io/styleguide/cppguide.html#Copyable_Movable_Types
-    class SanlaMessagePackage {
-        uint8_t flags, payload_seq;
-        uint16_t sender_id, length;
-        long package_id, payload_chks;
+    struct MessageHeader {
+        u_char flags;
+        uint8_t payload_seq;
+        uint16_t length;
+        uint64_t sender_id, payload_chks;
+        uint32_t package_id;
         std::string recipient_id;
+    };
+
+    class SanlaMessagePackage {
+        MessageHeader header;
         MessageBody body;
 
         public:
-        SanlaMessagePackage (uint8_t, uint8_t, uint16_t, 
-        uint16_t, long, long, std::string, MessageBody);
-        ~SanlaMessagePackage ();
+        SanlaMessagePackage(u_char, uint8_t, uint16_t, 
+        uint64_t, uint64_t, uint32_t, std::string, MessageBody);
+        SanlaMessagePackage(MessageHeader, MessageBody);
+        // This class is not moveable
+        SanlaMessagePackage(SanlaMessagePackage&&) = delete;
+        SanlaMessagePackage& operator=(SanlaMessagePackage&&) = delete;
+        // This class is not copyable
+        SanlaMessagePackage(const SanlaMessagePackage&) = delete;
+        SanlaMessagePackage& operator=(const SanlaMessagePackage&) = delete;
+
+        ~SanlaMessagePackage();
+
+        uint8_t GetPackageLength();
+        uint16_t GetTotalPackageLength();
+        MessageHeader& GetPackageHeader();
+        MessageBody& GetPackageBody();
     };
 };
 #endif

--- a/src/SanlaMessage.cpp
+++ b/src/SanlaMessage.cpp
@@ -1,0 +1,39 @@
+#include <sstream>
+#include "common/SanlaMessage.hpp"
+
+using namespace sanla;
+
+SanlaMessagePackage::SanlaMessagePackage(u_char _flags, uint8_t _payload_seq, 
+uint16_t _length, uint64_t _sender_id, uint64_t _payload_chks, uint32_t _package_id,
+std::string _recipient_id, const MessageBody _body ) {
+    header.flags = _flags;
+    header.payload_seq = _payload_seq;
+    header.length = _length;
+    header.sender_id = _sender_id;
+    header.payload_chks = _payload_chks;
+    header.package_id = _package_id;
+    header.recipient_id = _recipient_id;
+    body = _body;
+
+}
+
+SanlaMessagePackage::SanlaMessagePackage(MessageHeader _header, MessageBody _body) {
+    header = _header;
+    body = _body;
+}
+
+uint8_t SanlaMessagePackage::GetPackageLength() {
+    return header.payload_seq;
+}
+
+uint16_t SanlaMessagePackage::GetTotalPackageLength() {
+    return header.length;
+}
+
+MessageHeader& SanlaMessagePackage::GetPackageHeader() {
+    return header;
+}
+
+MessageBody& SanlaMessagePackage::GetPackageBody() {
+    return body;
+}


### PR DESCRIPTION
- Message header information is now stored in its own struct instead of in SanlaMessagePackage
- Removed Copy and Move constructors from SanlaMessagePackage