### PR TITLE
Unify SanlaMessage payload with SanlaPacket. Move SanlaMessage under namespace sanla::messaging

### DIFF
--- a/include/LoRaModule.hpp
+++ b/include/LoRaModule.hpp
@@ -66,7 +66,7 @@ namespace sanla {
              * @param _recipient_id Recipient group id.
              * @return sanla::MessageHeader Complete message header.
              */
-            sanla::MessageHeader buildUserInputHeader(RecipientId_t);
+            sanla::messaging::MessageHeader buildUserInputHeader(RecipientId_t);
 
             /**
              * @brief Build a message body based on user input.
@@ -74,7 +74,7 @@ namespace sanla {
              * @param _payload User input text.
              * @return sanla::MessageBody Complete message body.
              */
-            sanla::MessageBody buildUserInputBody(String);
+            sanla::messaging::sanlamessage::Payload_t * buildUserInputBody(String);
         };
 
     };

--- a/include/common/SanlaMessage.hpp
+++ b/include/common/SanlaMessage.hpp
@@ -9,38 +9,38 @@
 #include "common/typedefs.hpp"
 
 namespace sanla {
+    namespace messaging {
 
-    struct MessageBody {
-        char sender[messaging::sanlamessage::MESSAGE_BODY_SENDER_MAX_SIZE];
-        char payload[messaging::sanlamessage::MESSAGE_BODY_MAX_SIZE];
-    };
+        struct MessageHeader {
+            MessageId_t message_id;
+            SenderId_t sender_id;
+            PayloadChecksum_t payload_chks;
+            RecipientId_t recipient_id;
+        };
 
-    struct MessageHeader {
-        MessageId_t message_id;
-        SenderId_t sender_id;
-        PayloadChecksum_t payload_chks;
-        std::string recipient_id;
-    };
+        using Payload_t = messaging::sanlamessage::Payload_t;
 
-    class SanlaMessagePackage {
-        MessageHeader header;
-        MessageBody body;
+        class SanlaMessagePackage {
+            MessageHeader header;
+            Payload_t body;
 
-        public:
-        SanlaMessagePackage(uint32_t, uint16_t, uint32_t, MessageBody);
-        SanlaMessagePackage(MessageHeader, MessageBody);
-        // This class is not moveable
-        SanlaMessagePackage(SanlaMessagePackage&&) = delete;
-        SanlaMessagePackage& operator=(SanlaMessagePackage&&) = delete;
-        // This class is not copyable
-        SanlaMessagePackage(const SanlaMessagePackage&) = delete;
-        SanlaMessagePackage& operator=(const SanlaMessagePackage&) = delete;
+            public:
+            SanlaMessagePackage(MessageId_t, SenderId_t, PayloadChecksum_t, RecipientId_t, Payload_t);
+            SanlaMessagePackage(MessageHeader, Payload_t);
+            // This class is not moveable
+            SanlaMessagePackage(SanlaMessagePackage&&) = delete;
+            SanlaMessagePackage& operator=(SanlaMessagePackage&&) = delete;
+            // This class is not copyable
+            SanlaMessagePackage(const SanlaMessagePackage&) = delete;
+            SanlaMessagePackage& operator=(const SanlaMessagePackage&) = delete;
 
-        ~SanlaMessagePackage(){};
+            ~SanlaMessagePackage(){};
 
-        uint8_t GetPackageLength();
-        MessageHeader& GetPackageHeader();
-        MessageBody& GetPackageBody();
-    };
-};
+            uint16_t GetPackageLength();
+            MessageHeader& GetPackageHeader();
+            Payload_t& GetPackageBody();
+        };
+
+    }; // messaging
+}; // sanla
 #endif

--- a/include/common/SanlaPacket.hpp
+++ b/include/common/SanlaPacket.hpp
@@ -32,7 +32,7 @@ namespace sanla {
                 SanlaPacketHeader header;
                 sanlapacket::Payload_t body;
                 
-                void copy_headers_from_message(MessageHeader, MessageBody);
+                void copy_headers_from_message(MessageHeader, sanlamessage::Payload_t);
             };
 
             inline void htonSanlaPacketHeader(SanlaPacketHeader, sanlapacket::SerializedPacketHeader_t);

--- a/include/hw/MessageBuffer.hpp
+++ b/include/hw/MessageBuffer.hpp
@@ -9,7 +9,7 @@ namespace sanla {
     namespace hw_interfaces {
         namespace mq {
             using SanlaPacket = sanla::messaging::SanlaPacket;
-            using SanlaPackage = sanla::SanlaMessagePackage;
+            using SanlaPackage = sanla::messaging::SanlaMessagePackage;
             using PacketVector = std::vector<SanlaPacket>;
 
             class MessageBuffer {

--- a/src/LoRaModule.cpp
+++ b/src/LoRaModule.cpp
@@ -32,8 +32,8 @@ void LoRaModule::setRadioParameters() {
     LoRa.setSyncWord(SYNC_WORD);
 }
 
-sanla::MessageHeader buildUserInputHeader(RecipientId_t _recipient_id) {
-    sanla::MessageHeader header;
+sanla::messaging::MessageHeader buildUserInputHeader(RecipientId_t _recipient_id) {
+    sanla::messaging::MessageHeader header;
     header.message_id = 1; // TODO generate. UUID?
     header.sender_id = 65535; // TODO generate. MAC?
     header.payload_chks = 1; // TODO calculate. Given as input?
@@ -41,19 +41,17 @@ sanla::MessageHeader buildUserInputHeader(RecipientId_t _recipient_id) {
     return header;
 }
 
-sanla::MessageBody buildUserInputBody(String _payload) {
-    sanla::MessageBody body;
-    strncpy(body.sender, "foo", sizeof("foo")); // TODO how to get this?
-    strncpy(body.payload, _payload.c_str(), sizeof(_payload));
+sanla::messaging::sanlamessage::Payload_t* buildUserInputBody(String _payload) {
+    sanla::messaging::sanlamessage::Payload_t* body;
+    strcpy(*body, _payload.c_str());
 
     return body;
 }
 
 void LoRaModule::sendMessage(String _input) {
 
-    sanla::MessageHeader header = sanla::lora::buildUserInputHeader("sanla__"); // TODO where to get recipient id?
-    sanla::MessageBody body = sanla::lora::buildUserInputBody(_input);
-    sanla::SanlaMessagePackage package(header, body);
+    sanla::messaging::MessageHeader header = sanla::lora::buildUserInputHeader("sanla__"); // TODO where to get recipient id?
+    sanla::messaging::SanlaMessagePackage package(header, *sanla::lora::buildUserInputBody(_input));
 
     // TODO send package to MessageStore for broadcasting.
 
@@ -62,11 +60,11 @@ void LoRaModule::sendMessage(String _input) {
     packet.header.flags = sanla::messaging::PRO;
     packet.header.message_id = 4294967295;
     packet.header.sender_id = 65535;
-    strncpy(packet.header.recipient_id, "asdfasdf", sanla::messaging::RECIPIENT_ID_MAX_SIZE);
+    strcpy(packet.header.recipient_id, "asdfasdf");
     packet.header.message_payload_length = 65535;
     packet.header.payload_seq = 65535;
     packet.header.payload_chks = 4294967295;
-    strncpy(packet.body, "12345678901234567890", sizeof("12345678901234567890"));
+    strcpy(packet.body, "12345678901234567890");
 
     // TODO may be removed from here.
     sanla::messaging::sanlapacket::SerializedPacket_t buffer{};

--- a/src/MessageStore.cpp
+++ b/src/MessageStore.cpp
@@ -10,11 +10,11 @@ namespace mq {
 
 SanlaPacket MessageStore::GetPackagePart(MessageId_t packageId, size_t payloadStartPos) {
     auto package = m_store[packageId]; // TODO catch exceptions raised here and inform method caller
-    std::string msg(package->GetPackageBody().payload);
+    std::string msg(package->GetPackageBody());
     auto new_payload = msg.substr(payloadStartPos, sanla::messaging::sanlapacket::PACKET_BODY_MAX_SIZE).c_str();
     SanlaPacket output{};
     output.copy_headers_from_message(package->GetPackageHeader(), package->GetPackageBody());
-    strncpy(output.body, new_payload, sanla::messaging::sanlapacket::PACKET_BODY_MAX_SIZE); // Possible segfault due to missing Null terminator
+    strcpy(output.body, new_payload); // Possible segfault due to missing Null terminator
     return output;
 
 }

--- a/src/SanlaMessage.cpp
+++ b/src/SanlaMessage.cpp
@@ -4,42 +4,40 @@
 #include "common/SanlaPacket.hpp"
 
 namespace sanla {
+    namespace messaging {
 
-SanlaMessagePackage::SanlaMessagePackage(MessageId_t _message_id, SenderId_t _sender_id, PayloadChecksum_t _payload_chks, const MessageBody _body ) {
-    header.message_id = _message_id;
-    header.sender_id = _sender_id;
-    header.payload_chks = _payload_chks;
-    //header.recipient_id = _recipient_id;
-    body = _body;
-}
+        SanlaMessagePackage::SanlaMessagePackage(MessageId_t _message_id, SenderId_t _sender_id, PayloadChecksum_t _payload_chks, RecipientId_t _recipient_id, Payload_t _body ) {
+            header.message_id = _message_id;
+            header.sender_id = _sender_id;
+            header.payload_chks = _payload_chks;
+            strcpy(header.recipient_id, _recipient_id);
+            strcpy(body, _body);
+        }
 
-SanlaMessagePackage::SanlaMessagePackage(MessageHeader _header, MessageBody _body) {
-    header = _header;
-    body = _body;
-}
+        SanlaMessagePackage::SanlaMessagePackage(MessageHeader _header, Payload_t _body) {
+            header = _header;
+            strcpy(body, _body);
+        }
 
-uint8_t SanlaMessagePackage::GetPackageLength() {
-    // TODO calculate real payload length
-    return 123;
-}
+        uint16_t SanlaMessagePackage::GetPackageLength() {
+            return strlen(body);
+        }
 
-MessageHeader& SanlaMessagePackage::GetPackageHeader() {
-    return header;
-}
+        MessageHeader& SanlaMessagePackage::GetPackageHeader() {
+            return header;
+        }
 
-MessageBody& SanlaMessagePackage::GetPackageBody() {
-    return body;
-}
+        Payload_t& SanlaMessagePackage::GetPackageBody() {
+            return body;
+        }
 
-namespace messaging {
-    void SanlaPacket::copy_headers_from_message(MessageHeader header, MessageBody body) {
-        MessageId_t message_id = header.message_id;
-        SenderId_t sender_id = header.sender_id;
-        PayloadChecksum_t payload_chks = header.payload_chks;
-        char recipient_id[header.recipient_id.length()+1];
-        strcpy(recipient_id, header.recipient_id.c_str());
-        PayloadLength_t message_payload_length = strlen(body.payload); // Possible segfault due to non Null terminated string
-
-    }
-} // messaging
+        void SanlaPacket::copy_headers_from_message(MessageHeader header, Payload_t body) {
+                MessageId_t message_id = header.message_id;
+                SenderId_t sender_id = header.sender_id;
+                PayloadChecksum_t payload_chks = header.payload_chks;
+                RecipientId_t recipient_id;
+                strcpy(recipient_id, header.recipient_id);
+                PayloadLength_t message_payload_length = strlen(body); // Possible segfault due to non Null terminated string
+        }
+    } // messaging
 } // sanla


### PR DESCRIPTION
Removes the previous payload struct approach and replaces with similar to SanlaPacket.
Moves SanlaMessagePackage from namespace 'sanla' into 'sanla::messaging'